### PR TITLE
Fix dig wrong values

### DIFF
--- a/hook.sh
+++ b/hook.sh
@@ -204,7 +204,7 @@ function check_dns_propagation() {
   while [[ true ]]
   do
     sleep 5;
-    local SOA=$( dig +short SOA $dns_zone| cut -d' ' -f1);
+    local SOA=$( dig +short SOA $dns_zone| cut -d' ' -f1 | grep -v '^;;$');
     local tokens=$( nslookup -type=TXT "$record_name.$dns_zone" $SOA );
 
     while IFS= read -r line


### PR DESCRIPTION
When a DNS server isn't working, the command dig used to get the SOA will return ";;", which doesn't work with nslookup.  Add a grep command to remove these lines.